### PR TITLE
Created simple api util to abstract api calls away and handle login/token stuff in the feature

### DIFF
--- a/src/containers/SongsTable/SongsTable.js
+++ b/src/containers/SongsTable/SongsTable.js
@@ -13,12 +13,16 @@ class SongsTable extends Component {
   }
 
   componentDidMount() {
-    XmasAPI.fetchSongs(this, function (json, context) {context.setState({
-      loaded: true,
-      data: json.data.Songs
-    })}, function (error, context) {
-      console.log(error);
-    });
+    XmasAPI.fetchSongs()
+      .then(json => {
+        this.setState({
+          loaded: true,
+          data: json.data.Songs
+        })
+      })
+      .catch(error => {
+        console.log(error)
+      })
   }
 
   renderLoadingView() {

--- a/src/containers/SongsTable/SongsTable.js
+++ b/src/containers/SongsTable/SongsTable.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import CircularProgress from 'material-ui/CircularProgress';
-import './SongsTable.css'
+import './SongsTable.css';
+import XmasAPI from '../../utils/XmasAPI'
 
 class SongsTable extends Component {
   constructor() {
@@ -12,29 +13,12 @@ class SongsTable extends Component {
   }
 
   componentDidMount() {
-    this.fetchData()
-  }
-
-  fetchData() {
-    const query = `{
-      Songs {
-        artist,
-        title,
-        image,
-        url
-      }
-    }`
-    fetch(`https://back.christmastop100.nl/graphql?query=${query}`)
-      .then(response => response.json())
-      .then(json => {
-        this.setState({
-          loaded: true,
-          data: json.data.Songs
-        })
-      })
-      .catch(error => {
-        console.log(error);
-      });
+    XmasAPI.fetchSongs(this, function (json, context) {context.setState({
+      loaded: true,
+      data: json.data.Songs
+    })}, function (error, context) {
+      console.log(error);
+    });
   }
 
   renderLoadingView() {

--- a/src/utils/XmasAPI.js
+++ b/src/utils/XmasAPI.js
@@ -1,0 +1,21 @@
+class XmasAPI {
+  static fetchSongs(context, callback, errorCallback) {
+    const query = `{
+      Songs {
+        artist,
+        title,
+        image,
+        url
+      }
+    }`
+    fetch(`https://back.christmastop100.nl/graphql?query=${query}`)
+      .then(response => response.json())
+      .then(json => {
+        callback(json, context);
+      })
+      .catch(error => {
+        errorCallback(error, context);
+      });
+  }
+}
+export default XmasAPI

--- a/src/utils/XmasAPI.js
+++ b/src/utils/XmasAPI.js
@@ -8,14 +8,8 @@ class XmasAPI {
         url
       }
     }`
-    fetch(`https://back.christmastop100.nl/graphql?query=${query}`)
+    return fetch(`https://back.christmastop100.nl/graphql?query=${query}`)
       .then(response => response.json())
-      .then(json => {
-        callback(json, context);
-      })
-      .catch(error => {
-        errorCallback(error, context);
-      });
   }
 }
 export default XmasAPI


### PR DESCRIPTION
Het meegeven van 'this' aan de fetchsongs method is nu nog lelijk, weet niet helemaal of dat ook mooier kan en hoe dat dan moet. Lijkt mij wel dat het mogelijk moet zijn om die direct aan de callback mee te geven ipv via de fetchSongs method.

fetchSongs is nu static, weet ook niet of dat logisch is. De bedoeling is dat de meeste logica uit die functie gaat en naar andere niet static functies in die class, om her te gebruiken en om een soort singleton te kunnen maken zodat er altijd 1 token is die in alle calls vanuit alle componenten wordt gebruikt.